### PR TITLE
Bug fix on IsPrime

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -59,7 +59,7 @@ export function IsPrime(num: number): boolean {
     if (num % 2 === 0)
         return false;
     
-    for (let i = 3; i < Math.sqrt(num); i+=2)
+    for (let i = 3; i <= Math.sqrt(num); i+=2)
         if (num % i === 0)
             return false;
     


### PR DESCRIPTION
It should be going to AND including the square root of the number, in the event that the square root happens to be a whole odd number.